### PR TITLE
actualizacion de Ids y eliminiacion de atributos innecesarios

### DIFF
--- a/estacionesDB
+++ b/estacionesDB
@@ -3,28 +3,26 @@ db.createCollection("provincias", {
    validator: {
       $jsonSchema: {
          bsonType: "object",
-         required: ["idProvincia", "nombre"],
+         required: ["_id", "nombre"],
          properties: {
-            idProvincia: { bsonType: "int" },
+            _id: { bsonType: "objectId" },
             nombre: { bsonType: "string" },
             municipios: {
                bsonType: "array",
+               description: "lista de municipios incluidos en la provincia"
                items: {
                   bsonType: "object",
-                  required: ["idMunicipio", "nombre"],
+                  required: ["nombre"],
                   properties: {
-                     idMunicipio: { bsonType: "int" },
-                     nombre: { bsonType: "string" },
-                     localidades: {
+                    nombre: { bsonType: "string" },
+                    localidades: {
                         bsonType: "array",
+                        description: "lista de localidades incluidas en e; municipio",
                         items: {
-                           bsonType: "object",
-                           properties: {
-                              idLocalidad: { bsonType: "int" },
-                              nombre: { bsonType: "string" }
-                           }
+                            bsonType: "object",
+                            required: ["nombre"]
                         }
-                     }
+                    }
                   }
                }
             }
@@ -36,22 +34,18 @@ db.createCollection("estaciones", {
    validator: {
       $jsonSchema: {
          bsonType: "object",
-         required: ["idEstacion", "rotulo", "ubicacion", "esTerrestre"],
+         required: ["_id", "rotulo", "ubicacion", "esTerrestre"],
          properties: {
-            idEstacion: { bsonType: "int" },
+            _id: { bsonType: "objectId" },
             rotulo: {
-               bsonType: "object",
-               required: ["idRotulo", "nombre"],
-               properties: {
-                  idRotulo: { bsonType: "int" },
-                  nombre: { bsonType: "string" }
-               }
+               bsonType: "objectId",
+               description: "id del rotulo en la coleccion rotulos"
             },
             ubicacion: {
                bsonType: "object",
                required: ["provincia", "municipio", "localidad", "codigoPostal", "direccion"],
                properties: {
-                  provincia: { bsonType: "string" },
+                  provincia: { bsonType: "objectId" },
                   municipio: { bsonType: "string" },
                   localidad: { bsonType: "string" },
                   codigoPostal: { bsonType: "string" },
@@ -69,14 +63,14 @@ db.createCollection("estaciones", {
                   }
                }
             },
+            esTerrestre: {bsonType: "bool"}
             tarifas: {
                bsonType: "array",
                items: {
                   bsonType: "object",
-                  required: ["idCarburante", "precio", "fecha"],
+                  required: ["carburante", "precio", "fecha"],
                   properties: {
-                     idCarburante: { bsonType: "int" },
-                     nombreCarburante: { bsonType: "string" },
+                     carburante: { bsonType: "objectId" },
                      precio: { bsonType: "double" },
                      fecha: { bsonType: "date" }
                   }
@@ -90,9 +84,9 @@ db.createCollection("carburantes", {
    validator: {
       $jsonSchema: {
          bsonType: "object",
-         required: ["idCarburante", "nombre"],
+         required: ["_id", "nombre"],
          properties: {
-            idCarburante: { bsonType: "int" },
+            _id: { bsonType: "objectId" },
             nombre: { bsonType: "string" }
          }
       }
@@ -103,9 +97,9 @@ db.createCollection("rotulos", {
    validator: {
       $jsonSchema: {
          bsonType: "object",
-         required: ["idRotulo", "nombre"],
+         required: ["_id", "nombre"],
          properties: {
-            idRotulo: { bsonType: "int" },
+            _id: { bsonType: "objectId" },
             nombre: { bsonType: "string" }
          }
       }
@@ -113,18 +107,18 @@ db.createCollection("rotulos", {
 })
 // Índices para estaciones
 db.estaciones.createIndex({ "ubicacion.coordenadas": "2dsphere" })
-db.estaciones.createIndex({ "rotulo.idRotulo": 1 })
+db.estaciones.createIndex({ "rotulo": 1 })
 db.estaciones.createIndex({ "ubicacion.provincia": 1, "ubicacion.municipio": 1, "ubicacion.localidad": 1 }, { name: "idx_ubicacion" })
 db.estaciones.createIndex({ "esTerrestre": 1 })
+db.estaciones.createIndex({ "tarifas.carburante": 1 });
 
 // Índices para provincias
 db.provincias.createIndex({ "nombre": 1 })
-db.provincias.createIndex({ "municipios.nombre": 1 })
-db.provincias.createIndex({ "municipios.localidades.nombre": 1 })
+db.provincias.createIndex({ "municipios.nombre": 1 });
+db.provincias.createIndex({ "municipios.localidades.nombre": 1 });
+
+// Índices para carburantes
+db.carburantes.createIndex({ "nombre": 1 })
 
 // Índices para rótulos
 db.rotulos.createIndex({ "nombre": 1 })
-
-
-
-

--- a/estaciones_extra_colecciones
+++ b/estaciones_extra_colecciones
@@ -1,0 +1,149 @@
+use estacionesDB
+db.createCollection("provincias", {
+   validator: {
+      $jsonSchema: {
+         bsonType: "object",
+         required: ["_id", "nombre"],
+         properties: {
+            _id: { bsonType: "objectId" },
+            nombre: { bsonType: "string" },
+            municipios: {
+               bsonType: "array",
+               description: "lista de municipios incluidos en la provincia"
+               items: {
+                  bsonType: "objectId",
+                  description: "id del municipio en la coleccion de municipios"
+               }
+            }
+         }
+      }
+   }
+})
+db.createCollection("municipios", {
+   validator: {
+      $jsonSchema: {
+         bsonType: "object",
+         required: ["_id", "nombre"],
+         properties: {
+            _id: { bsonType: "objectId" },
+            nombre: { bsonType: "string" },
+            localidades: {
+               bsonType: "array",
+               description: "lista de localidades incluidas en el municipio"
+               items: {
+                  bsonType: "objectId",
+                  description: "id de la localidad en la coleccion de localidades"
+               }
+            }
+         }
+      }
+   }
+})
+db.createCollection("localidades", {
+   validator: {
+      $jsonSchema: {
+         bsonType: "object",
+         required: ["_id", "nombre"],
+         properties: {
+            _id: { bsonType: "objectId" },
+            nombre: { bsonType: "string" },
+         }
+      }
+   }
+})
+db.createCollection("estaciones", {
+   validator: {
+      $jsonSchema: {
+         bsonType: "object",
+         required: ["_id", "rotulo", "ubicacion", "esTerrestre"],
+         properties: {
+            _id: { bsonType: "objectId" },
+            rotulo: {
+               bsonType: "objectId",
+               description: "id del rotulo en la coleccion rotulos"
+            },
+            ubicacion: {
+               bsonType: "object",
+               required: ["provincia", "municipio", "localidad", "codigoPostal", "direccion"],
+               properties: {
+                  localidad: { bsonType: "objectId" },
+                  codigoPostal: { bsonType: "string" },
+                  direccion: { bsonType: "string" },
+                  coordenadas: {
+                     bsonType: "object",
+                     required: ["type", "coordinates"],
+                     properties: {
+                        type: { bsonType: "string" },
+                        coordinates: {
+                           bsonType: "array",
+                           items: { bsonType: "double" }
+                        }
+                     }
+                  }
+               }
+            },
+            esTerrestre: {bsonType: "bool"}
+            tarifas: {
+               bsonType: "array",
+               items: {
+                  bsonType: "object",
+                  required: ["idCarburante", "precio", "fecha"],
+                  properties: {
+                     idCarburante: { bsonType: "int" },
+                     nombreCarburante: { bsonType: "string" },
+                     precio: { bsonType: "double" },
+                     fecha: { bsonType: "date" }
+                  }
+               }
+            }
+         }
+      }
+   }
+})
+db.createCollection("carburantes", {
+   validator: {
+      $jsonSchema: {
+         bsonType: "object",
+         required: ["_id", "nombre"],
+         properties: {
+            _id: { bsonType: "objectId" },
+            nombre: { bsonType: "string" }
+         }
+      }
+   }
+})
+
+db.createCollection("rotulos", {
+   validator: {
+      $jsonSchema: {
+         bsonType: "object",
+         required: ["_id", "nombre"],
+         properties: {
+            _id: { bsonType: "objectId" },
+            nombre: { bsonType: "string" }
+         }
+      }
+   }
+})
+// Índices para estaciones
+db.estaciones.createIndex({ "ubicacion.coordenadas": "2dsphere" })
+db.estaciones.createIndex({ "rotulo._id": 1 })
+db.estaciones.createIndex({ "ubicacion.localidad": 1 })
+db.estaciones.createIndex({ "esTerrestre": 1 })
+
+// Índices para provincias
+db.provincias.createIndex({ "nombre": 1 })
+db.provincias.createIndex({ "municipios._id": 1 })
+
+// Índices para municipios
+db.municipios.createIndex({ "nombre": 1 })
+db.municipios.createIndex({ "localidades._id": 1 })
+
+// Índices para localidades
+db.localidades.createIndex({ "nombre": 1 })
+
+// Índices para carburantes
+db.carburantes.createIndex({ "nombre": 1 })
+
+// Índices para rótulos
+db.rotulos.createIndex({ "nombre": 1 })


### PR DESCRIPTION
Cambios:
1. Cambiado nomenclatura de ids a _id (convencion)
2. Cambiado el tipo de los ids a objectId (tipo nativo de mongo)
3. Eliminado atributos municipioId, localidadId: si no hay una colecci'on para ellos, ese id no tiene sentido, es una referencia a la nada. Guardamos solo el nombre
4. Eliminado datos redundantes en estaciones, como nombreCarburante y rotulo.nombre. Si tenemos colecciones separadas para rotulo y carburante (que en realidad solo contienen el nombre), no tiene sentido volver a incluir esos datos en estaciones: ocupan espacio innecesario Y son vulnerables a inconsistencias. Es mejor referenciar solo el id (la búsqueda extra que hay que hacer en rótulos o carburantes en vez de mirar el nombre en el doc de la estación es muy poco pesada, ya que es por id). Si no, embembemos el doc entero como hemos hecho con municipios y localidades. Pero tener una colección con nombres de rótulos si los vamos a mirar directamente en estaciones, no es útil
5. Añadido un par de índices